### PR TITLE
ci: split build jobs for platforms & split build-release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,167 @@
+name: Build release artifacts
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      upload-artifacts:
+        type: boolean
+        default: false
+      artifacts-retention-days:
+        type: number
+        default: 1
+  workflow_call:
+    inputs:
+      upload-artifacts:
+        type: boolean
+        default: false
+      artifacts-retention-days:
+        type: number
+        default: 3
+
+jobs:
+  build-linux-x86_64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+      - name: node_modules cache
+        uses: actions/cache@v4.0.2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+      - name: externals cache
+        uses: actions/cache@v4.0.2
+        with:
+          path: externals
+          key: ${{ runner.os }}-externals-${{ hashFiles('scripts/prepare-*.sh') }}
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 20
+      - name: Install yarn
+        run: npm install -g yarn
+      - name: Install dependencies
+        run: yarn install
+      - name: Prepare & build
+        run: |
+          bash ./scripts/prepare-linux.sh
+          bash ./scripts/build-linux.sh
+      - name: Upload build artifacts
+        if: inputs.upload-artifacts == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bin-linux-arm64
+          path: bin
+          retention-days: ${{ inputs.artifacts-retention-days }}
+
+  build-linux-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+      - name: node_modules cache
+        uses: actions/cache@v4.0.2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+      - name: externals cache
+        uses: actions/cache@v4.0.2
+        with:
+          path: externals
+          key: ${{ runner.os }}-externals-${{ hashFiles('scripts/prepare-*.sh') }}
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 20
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/arm64
+      - name: Prepare & build
+        run: |
+          docker run --rm \
+            -e CMAKE_BUILD_PARALLEL_LEVEL=${{ env.CMAKE_BUILD_PARALLEL_LEVEL }} \
+            -v $(pwd):/${{ github.workspace }} \
+            -w /${{ github.workspace }} \
+            --platform linux/arm64 \
+            arm64v8/ubuntu:latest \
+            bash -c "./scripts/prepare-linux.sh && ./scripts/build-linux.sh"
+      - name: Upload build artifacts
+        if: inputs.upload-artifacts == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bin-linux-arm64
+          path: bin
+          retention-days: ${{ inputs.artifacts-retention-days }}
+
+  build-macos:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-13, macos-14]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+      - name: node_modules cache
+        uses: actions/cache@v4.0.2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+      - name: externals cache
+        uses: actions/cache@v4.0.2
+        with:
+          path: externals
+          key: ${{ runner.os }}-externals-${{ hashFiles('scripts/prepare-*.sh') }}
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 20
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install
+      - name: Build (macOS)
+        run: bash ./scripts/build-macos.sh
+      - name: Upload build artifacts
+        if: inputs.upload-artifacts == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bin-macos
+          path: bin
+          retention-days: ${{ inputs.artifacts-retention-days }}
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+      - name: node_modules cache
+        uses: actions/cache@v4.0.2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+      - name: externals cache
+        uses: actions/cache@v4.0.2
+        with:
+          path: externals
+          key: ${{ runner.os }}-externals-${{ hashFiles('scripts/prepare-*.ps1') }}
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 20
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install
+      - name: Prepare & build
+        run: |
+          powershell ./scripts/prepare-windows.ps1
+          powershell ./scripts/build-windows.ps1
+      - name: Upload build artifacts
+        if: inputs.upload-artifacts == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bin-windows
+          path: bin
+          retention-days: ${{ inputs.artifacts-retention-days }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -127,7 +127,7 @@ jobs:
         if: inputs.upload-artifacts == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: bin-macos
+          name: bin-${{ matrix.os }}
           path: bin
           retention-days: ${{ inputs.artifacts-retention-days }}
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,6 +1,5 @@
 name: Build release artifacts
 on:
-  push:
   workflow_dispatch:
     inputs:
       upload-artifacts:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -49,7 +49,7 @@ jobs:
         if: inputs.upload-artifacts == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: bin-linux-arm64
+          name: bin-linux-x86_64
           path: bin
           retention-days: ${{ inputs.artifacts-retention-days }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,70 +7,10 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: 'true'
-      - name: Setup QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/arm64
-      - uses: actions/setup-node@v4.0.2
-        with:
-          node-version: 20
-          cache: 'yarn'
-      - name: node_modules cache
-        uses: actions/cache@v4.0.2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
-      - name: externals cache
-        uses: actions/cache@v4.0.2
-        if: runner.os != 'Windows'
-        with:
-          path: externals
-          key: ${{ runner.os }}-externals-${{ hashFiles('scripts/prepare-*.sh') }}
-      - name: externals cache (Windows)
-        uses: actions/cache@v4.0.2
-        if: runner.os == 'Windows'
-        with:
-          path: externals
-          key: ${{ runner.os }}-externals-${{ hashFiles('scripts/prepare-*.ps1') }}
-      - name: Install dependencies
-        run: yarn install
-      - name: Prepare & build (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          powershell ./scripts/prepare-windows.ps1
-          powershell ./scripts/build-windows.ps1
-      - name: Prepare & build (Linux x86_64)
-        if: runner.os == 'Linux'
-        run: |
-          bash ./scripts/prepare-linux.sh
-          bash ./scripts/build-linux.sh
-      - name: Prepare & build (Linux arm64)
-        if: runner.os == 'Linux'
-        run: |
-          docker run --rm \
-            -v $(pwd):/${{ github.workspace }} \
-            -w /${{ github.workspace }} \
-            --platform linux/arm64 \
-            arm64v8/ubuntu:latest \
-            bash -c "./scripts/prepare-linux.sh && ./scripts/build-linux.sh"
-      - name: Build (macOS)
-        if: runner.os == 'macOS'
-        run: bash ./scripts/build-macos.sh
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: bin-${{ matrix.os }}
-          path: bin
-          retention-days: 3
+    uses: ./.github/workflows/build-release.yml
+    with:
+      upload-artifacts: true
+      artifacts-retention-days: 3
   publish:
     permissions:
       contents: write


### PR DESCRIPTION
I feel like the current release steps is a bit hard to read as it contains many platform-specific checks, so I just split it to multiple jobs.

Also, I split the release build into another workflow so we can easily to test each commit by triggering the workflow.