### PR TITLE
feat: use new linux arm runner for build build-linux-arm64 & off GGML_NATIVE

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -54,7 +54,7 @@ jobs:
           retention-days: ${{ inputs.artifacts-retention-days }}
 
   build-linux-arm64:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@v4
         with:
@@ -75,19 +75,10 @@ jobs:
           cache: "yarn"
       - name: Install dependencies
         run: yarn install
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/arm64
       - name: Prepare & build
         run: |
-          docker run --rm \
-            -e CMAKE_BUILD_PARALLEL_LEVEL=${{ env.CMAKE_BUILD_PARALLEL_LEVEL }} \
-            -v $(pwd):/${{ github.workspace }} \
-            -w /${{ github.workspace }} \
-            --platform linux/arm64 \
-            arm64v8/ubuntu:latest \
-            bash -c "./scripts/prepare-linux.sh && ./scripts/build-linux.sh"
+          bash ./scripts/prepare-linux.sh
+          bash ./scripts/build-linux.sh
       - name: Upload build artifacts
         if: github.event.inputs.upload-artifacts == 'YES' || inputs.upload-artifacts == 'YES'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -72,7 +72,8 @@ jobs:
       - uses: actions/setup-node@v4.0.2
         with:
           node-version: 20
-          cache: "yarn"
+      - name: Install yarn
+        run: npm install -g yarn
       - name: Install dependencies
         run: yarn install
       - name: Prepare & build

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -10,6 +10,6 @@ if [ $ARCH == "x86_64" ]; then
   yarn clean && yarn build-native
   yarn clean && yarn build-native --CDLLAMA_VULKAN=1 --CDVARIANT=vulkan
 else
-  yarn clean && yarn build-native
-  yarn clean && yarn build-native --CDLLAMA_VULKAN=1 --CDVULKAN_SDK="$(realpath 'externals/arm64-Vulkan-SDK')" --CDVARIANT=vulkan
+  yarn clean && yarn build-native --CDGGML_NATIVE=OFF
+  yarn clean && yarn build-native --CDGGML_NATIVE=OFF --CDLLAMA_VULKAN=1 --CDVULKAN_SDK="$(realpath 'externals/arm64-Vulkan-SDK')" --CDVARIANT=vulkan
 fi


### PR DESCRIPTION
Ref: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview

- [x] Test build: https://github.com/mybigday/llama.node/actions/runs/12848659581
- [x] Test cpu bin in Jetson platform