### PR TITLE
feat: sync llama.cpp to b6327

### DIFF
--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -27,7 +27,8 @@ export type LlamaModelOptions = {
   n_ubatch?: number
   n_threads?: number
   n_gpu_layers?: number
-  flash_attn?: boolean
+  flash_attn_type?: 'auto' | 'on' | 'off'
+  flash_attn?: boolean // Deprecated: use flash_attn_type instead
   cache_type_k?:
     | 'f16'
     | 'f32'

--- a/src/LlamaContext.cpp
+++ b/src/LlamaContext.cpp
@@ -190,6 +190,15 @@ static ggml_type kv_cache_type_from_str(const std::string &s) {
   throw std::runtime_error("Unsupported cache type: " + s);
 }
 
+static enum llama_flash_attn_type flash_attn_type_from_str(const std::string &s) {
+  if (s == "on")
+    return LLAMA_FLASH_ATTN_TYPE_ENABLED;
+  if (s == "off")
+    return LLAMA_FLASH_ATTN_TYPE_DISABLED;
+  return LLAMA_FLASH_ATTN_TYPE_AUTO;
+}
+
+
 static int32_t pooling_type_from_str(const std::string &s) {
   if (s == "none")
     return LLAMA_POOLING_TYPE_NONE;
@@ -242,7 +251,14 @@ LlamaContext::LlamaContext(const Napi::CallbackInfo &info)
   params.cpuparams.n_threads =
       get_option<int32_t>(options, "n_threads", cpu_get_num_math() / 2);
   params.n_gpu_layers = get_option<int32_t>(options, "n_gpu_layers", -1);
-  params.flash_attn = get_option<bool>(options, "flash_attn", false);
+
+  auto flash_attn_type = get_option<std::string>(options, "flash_attn_type", "auto");
+  if (!flash_attn_type.empty()) {
+    params.flash_attn_type = (enum llama_flash_attn_type)flash_attn_type_from_str(flash_attn_type.c_str());
+  } else {
+    params.flash_attn_type = get_option<bool>(options, "flash_attn", false) ? LLAMA_FLASH_ATTN_TYPE_ENABLED : LLAMA_FLASH_ATTN_TYPE_DISABLED;
+  }
+
   params.cache_type_k = kv_cache_type_from_str(
       get_option<std::string>(options, "cache_type_k", "f16").c_str());
   params.cache_type_v = kv_cache_type_from_str(


### PR DESCRIPTION
Deprecate `flash_attn` and introduce `flash_attn_type` (auto|on|off) context param.

TODO:
- [ ] Build release test: https://github.com/mybigday/llama.node/actions/runs/17351977769