### PR TITLE
feat: speedup windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,13 +64,23 @@ endif()
 # Improve speed
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
   if (MSVC)
-    if (NOT GGML_VULKAN)
+    # Enable parallel compilation for all MSVC builds
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
+
+    if (NOT GGML_VULKAN AND NOT GGML_CUDA)
+      # Full optimization with LTCG for default builds
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /O2 /Ob2 /Oi /Ot /Oy /GL")
       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /O2 /Ob2 /Oi /Ot /Oy /GL")
       set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} /LTCG")
-    else()
+    elseif(GGML_VULKAN)
+      # Reduced optimization for Vulkan builds
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /O1 /Ob1 /bigobj")
       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /O1 /Ob1 /bigobj")
+    else()
+      # Faster linking for CUDA builds (no LTCG)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /O2 /Ob2 /Oi")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /O2 /Ob2 /Oi")
     endif()
   else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -funroll-loops -flto=auto")

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -6,6 +6,9 @@ param (
 
 $ErrorActionPreference='Stop'
 
+# Enable parallel compilation
+$env:CMAKE_BUILD_PARALLEL_LEVEL = [Environment]::ProcessorCount
+
 $nativeArch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture
 
 if ($arch -eq "native") {

--- a/scripts/prepare-windows.ps1
+++ b/scripts/prepare-windows.ps1
@@ -23,8 +23,16 @@ if (($arch -eq "all" -or $arch -eq "x64") -and ($target -eq "all" -or $target -e
   }
 }
 
-if (Get-Command ccache -ErrorAction SilentlyContinue) {
+if (-Not (Get-Command ccache -ErrorAction SilentlyContinue)) {
   choco install ccache -y
+}
+
+# Configure ccache for optimal performance
+if (Get-Command ccache -ErrorAction SilentlyContinue) {
+  ccache --set-config=max_size=5G
+  ccache --set-config=compression=true
+  ccache --set-config=compiler_check=content
+  ccache -z  # Zero statistics
 }
 
 if ($toolchain -eq "mingw-clang") {


### PR DESCRIPTION
For node-llama-win32-x64-cuda: https://github.com/mybigday/llama.node/actions/runs/18631120612 - 49mins (was 110mins)